### PR TITLE
RD-166 : [ex-api] expoPushToken is not removed from db in some cases

### DIFF
--- a/lib/exponent_server_sdk/parser.ex
+++ b/lib/exponent_server_sdk/parser.ex
@@ -59,13 +59,9 @@ defmodule ExponentServerSdk.Parser do
     response
     |> Enum.with_index()
     |> Enum.map(fn {res, index} ->
-      if res["status"] == "error" && res["details"]["error"] == "DeviceNotRegistered" &&
+      if res["status"] == "error" and res["details"]["error"] == "DeviceNotRegistered" and
            is_nil(res["details"]["expoPushToken"]) do
-        details =
-          res["details"]
-          |> Map.put("expoPushToken", Enum.at(messages, index)[:to])
-
-        Map.put(res, "details", details)
+        put_in(res, ["details", "expoPushToken"], Enum.at(messages, index)[:to])
       else
         res
       end

--- a/lib/exponent_server_sdk/parser.ex
+++ b/lib/exponent_server_sdk/parser.ex
@@ -44,11 +44,31 @@ defmodule ExponentServerSdk.Parser do
       iex> return_value
       {:ok, [%{"id" => "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX", "status" => "ok"}, %{"id" => "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY", "status" => "ok"}]}
   """
-  @spec parse_list(HTTPoison.Response.t()) :: success_list | error
-  def parse_list(response) do
+  @spec parse_list(HTTPoison.Response.t(), [map()] | []) :: success_list | error
+  def parse_list(response, messages \\ []) do
     handle_errors(response, fn body ->
       {:ok, json} = Poison.decode(body)
+
       json["data"]
+      |> put_missing_expo_push_token(messages)
+    end)
+  end
+
+  @spec put_missing_expo_push_token([map()], [map()] | []) :: [any()]
+  def put_missing_expo_push_token(response, messages \\ []) when is_list(response) do
+    response
+    |> Enum.with_index()
+    |> Enum.map(fn {res, index} ->
+      if res["status"] == "error" && res["details"]["error"] == "DeviceNotRegistered" &&
+           is_nil(res["details"]["expoPushToken"]) do
+        details =
+          res["details"]
+          |> Map.put("expoPushToken", Enum.at(messages, index)[:to])
+
+        Map.put(res, "details", details)
+      else
+        res
+      end
     end)
   end
 

--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -27,7 +27,7 @@ defmodule ExponentServerSdk.PushNotification do
   Send the push notification request when using a single message map
   """
   @spec push(map()) :: Parser.success() | Parser.error()
-  def push(message) do
+  def push(message) when is_map(message) do
     message
     |> PushMessage.create()
 

--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -26,7 +26,7 @@ defmodule ExponentServerSdk.PushNotification do
   @doc """
   Send the push notification request when using a single message map
   """
-  @spec push(map()) :: Parser.success()() | Parser.error()
+  @spec push(map()) :: Parser.success() | Parser.error()
   def push(message) do
     message
     |> PushMessage.create()
@@ -38,7 +38,7 @@ defmodule ExponentServerSdk.PushNotification do
   @doc """
   Send the push notification request when using a list of message maps
   """
-  @spec push_list([map()]) :: Parser.success_list()() | Parser.error()
+  @spec push_list([map()]) :: Parser.success_list() | Parser.error()
   def push_list(messages) when is_list(messages) do
     messages
     |> PushMessage.create_from_list()

--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -47,20 +47,10 @@ defmodule ExponentServerSdk.PushNotification do
     |> Parser.parse_list(messages)
   end
 
-  # def push_messages_list([]), do: []
-
-  # @spec push_messages_list([map()]) :: Parser.success() | Parser.error()
-  # def push_messages_list([head | tail]) do
-  #   current_message = PushNotification.post!("send", head) |> Parser.parse_list()
-  #   [current_message | push_messages_list(tail)]
-  # end
-
   @doc """
   Send the get notification receipts request when using a list of ids
   """
-  @spec get_receipts(list()) :: Parser.success() | Parser.error() | boolean
-  def get_receipts([]), do: true
-
+  @spec get_receipts(list()) :: Parser.success() | Parser.error()
   def get_receipts(ids) when is_list(ids) do
     ids
     |> PushMessage.create_receipt_id_list()

--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -26,8 +26,8 @@ defmodule ExponentServerSdk.PushNotification do
   @doc """
   Send the push notification request when using a single message map
   """
-  @spec push(map()) :: Parser.success() | Parser.error()
-  def push(message) when is_map(message) do
+  @spec push(map()) :: Parser.success()() | Parser.error()
+  def push(message) do
     message
     |> PushMessage.create()
 
@@ -38,19 +38,29 @@ defmodule ExponentServerSdk.PushNotification do
   @doc """
   Send the push notification request when using a list of message maps
   """
-  @spec push_list(list(map())) :: Parser.success_list() | Parser.error()
+  @spec push_list([map()]) :: Parser.success_list()() | Parser.error()
   def push_list(messages) when is_list(messages) do
     messages
     |> PushMessage.create_from_list()
 
     PushNotification.post!("send", messages)
-    |> Parser.parse_list()
+    |> Parser.parse_list(messages)
   end
+
+  # def push_messages_list([]), do: []
+
+  # @spec push_messages_list([map()]) :: Parser.success() | Parser.error()
+  # def push_messages_list([head | tail]) do
+  #   current_message = PushNotification.post!("send", head) |> Parser.parse_list()
+  #   [current_message | push_messages_list(tail)]
+  # end
 
   @doc """
   Send the get notification receipts request when using a list of ids
   """
-  @spec get_receipts(list()) :: Parser.success() | Parser.error()
+  @spec get_receipts(list()) :: Parser.success() | Parser.error() | boolean
+  def get_receipts([]), do: true
+
   def get_receipts(ids) when is_list(ids) do
     ids
     |> PushMessage.create_receipt_id_list()


### PR DESCRIPTION
adding expo_push_token to individual messages errors as `DeviceNotRegistered`  which sometimes expo_push_token is not present in the response 